### PR TITLE
Resolves Uriil/unitywcf#3 by changing .NET version to 4.5

### DIFF
--- a/Unity.Wcf/Unity.Wcf.csproj
+++ b/Unity.Wcf/Unity.Wcf.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Unity.Wcf</RootNamespace>
     <AssemblyName>Unity.Wcf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Unity.Wcf/UnityContractBehavior.cs
+++ b/Unity.Wcf/UnityContractBehavior.cs
@@ -13,7 +13,7 @@ namespace Unity.Wcf
         {
             if (instanceProvider == null)
             {
-                throw new ArgumentNullException(nameof(instanceProvider));
+                throw new ArgumentNullException("instanceProvider");
             }
 
             _instanceProvider = instanceProvider;

--- a/Unity.Wcf/UnityInstanceContextExtension.cs
+++ b/Unity.Wcf/UnityInstanceContextExtension.cs
@@ -12,7 +12,7 @@ namespace Unity.Wcf
         {
             if (container == null)
             {
-                throw new ArgumentNullException(nameof(container));
+                throw new ArgumentNullException("container");
             }
 
             return _childContainer ?? (_childContainer = container.CreateChildContainer());
@@ -20,7 +20,10 @@ namespace Unity.Wcf
 
         public void DisposeOfChildContainer()
         {
-            _childContainer?.Dispose();
+            if (_childContainer != null)
+            {
+                _childContainer.Dispose();
+            }
         }
 
         public void Attach(InstanceContext owner)

--- a/Unity.Wcf/UnityInstanceProvider.cs
+++ b/Unity.Wcf/UnityInstanceProvider.cs
@@ -15,12 +15,12 @@ namespace Unity.Wcf
         {
             if (container == null)
             {
-                throw new ArgumentNullException(nameof(container));
+                throw new ArgumentNullException("container");
             }
 
             if (contractType == null)
             {
-                throw new ArgumentNullException(nameof(contractType));
+                throw new ArgumentNullException("contractType");
             }
 
             _container = container;

--- a/Unity.Wcf/UnityServiceHost.cs
+++ b/Unity.Wcf/UnityServiceHost.cs
@@ -12,7 +12,7 @@ namespace Unity.Wcf
         {
             if (container == null)
             {
-                throw new ArgumentNullException(nameof(container));
+                throw new ArgumentNullException("container");
             }
 
             ApplyServiceBehaviors(container);


### PR DESCRIPTION
The .NET target framework version is downgraded to v. 4.5 in order to support older projects. As a result some minor code changes were needed due to the change of C# version.

You have my full understanding if you decided to reject this PR and stick with the newer .NET version. However you will have my gratitude if you accept it as it'll allow me to use the NuGet package.

Take it or leave it :smile: 
